### PR TITLE
cmake: catch_add_rostest() add new target as dependency of 'tests' target

### DIFF
--- a/cmake/catch.cmake.em
+++ b/cmake/catch.cmake.em
@@ -65,6 +65,11 @@ function(catch_add_rostest_node target)
 		add_dependencies(${target} catch_ros_rostest)
 	endif()
 
+	# Make sure the test node is built before running any tests, see #8
+	if(TARGET tests)
+		add_dependencies(tests ${target})
+	endif()
+
 	target_link_libraries(${target}
 		@(DEVELSPACE ? CATKIN_DEVEL_PREFIX : CMAKE_INSTALL_PREFIX)/lib/libcatch_ros_rostest.so
 	)


### PR DESCRIPTION
This matches the behavior of `add_rostest_gtest()`. This way, users are not required to register
dependencies of their rostests on the individual test nodes.

Issue: #8.