### PR TITLE
[reporter] makes tests and failure from test-cases instead of assertions

### DIFF
--- a/src/ros_junit_reporter.h
+++ b/src/ros_junit_reporter.h
@@ -158,8 +158,8 @@ public:
 				it != itEnd;
 				++it )
 		{
-			failures += (*it)->value.totals.assertions.failed;
-			tests += (*it)->value.totals.assertions.total();
+			failures += (*it)->value.totals.testCases.failed;
+			tests += (*it)->value.totals.testCases.total();
 		}
 
 		xml.writeAttribute( "errors", totalUnexpectedExceptions );
@@ -181,8 +181,8 @@ public:
 		Catch::TestGroupStats const& stats = groupNode.value;
 		xml.writeAttribute( "name", m_config->name() );
 		xml.writeAttribute( "errors", unexpectedExceptions );
-		xml.writeAttribute( "failures", stats.totals.assertions.failed-unexpectedExceptions );
-		xml.writeAttribute( "tests", stats.totals.assertions.total() );
+		xml.writeAttribute( "failures", stats.totals.testCases.failed-unexpectedExceptions );
+		xml.writeAttribute( "tests", stats.totals.testCases.total() );
 		xml.writeAttribute( "hostname", "tbd" ); // !TBD
 
 		xml.writeAttribute( "package", catch_ros::meta::packageName() );


### PR DESCRIPTION
This report generated will have:
```
<test_suites tests={test_cases} failures={test_cases_failures} ..
  <testsuite tests={test_cases} failures={test_cases_failures} ..
```
instead of 
```
<test_suites tests={assertions} failures={assertions_failures} ..
  <testsuite tests={assertions} failures={assertions_failures} ..
```