### PR TITLE
Alternative implementation for catch_ros::meta::packageName()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,7 @@
 cmake_minimum_required(VERSION 3.4)
 project(catch_ros)
 
-find_package(catkin REQUIRED COMPONENTS
-	roscpp
-)
-
+find_package(catkin REQUIRED COMPONENTS roscpp)
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
 catkin_package(
@@ -16,23 +13,18 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
 add_library(catch_ros_standalone
-	src/standalone_main.cpp
+	src/standalone_main.cpp src/meta_info.cpp
 )
-target_link_libraries(catch_ros_standalone
-	${Boost_LIBRARIES}
-)
+target_compile_features(catch_ros_standalone PUBLIC cxx_std_11)
+target_link_libraries(catch_ros_standalone PRIVATE ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 
 add_library(catch_ros_rostest
-	src/rostest_main.cpp
+	src/rostest_main.cpp src/meta_info.cpp
 )
-target_link_libraries(catch_ros_rostest
-	${Boost_LIBRARIES}
-)
+target_compile_features(catch_ros_rostest PUBLIC cxx_std_11)
+target_link_libraries(catch_ros_rostest PRIVATE ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${CMAKE_DL_LIBS})
 
-install(FILES src/meta_info.cpp DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(TARGETS catch_ros_standalone catch_ros_rostest
 	LIBRARY DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
 )
@@ -40,4 +32,3 @@ install(TARGETS catch_ros_standalone catch_ros_rostest
 install(DIRECTORY include/${PROJECT_NAME}/
 	DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
-

--- a/cmake/catch.cmake.em
+++ b/cmake/catch.cmake.em
@@ -1,6 +1,3 @@
-
-add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")
-
 #
 # Add a Catch executable target.
 #
@@ -14,9 +11,11 @@ add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")
 # :type source_files: list of strings
 #
 function(catch_add_test target)
+	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${target}_meta_info.cpp"
+	"extern \"C\" { const char* catch_ros_local_package_name = \"${PROJECT_NAME}\"; }")
 	add_executable(${target}
 		${ARGN}
-		@(DEVELSPACE ? (PROJECT_SOURCE_DIR + "/src") : (CMAKE_INSTALL_PREFIX + "/" + CATKIN_PACKAGE_SHARE_DESTINATION))/meta_info.cpp
+		"${CMAKE_CURRENT_BINARY_DIR}/${target}_meta_info.cpp"
 	)
 
 	# If catch_ros_standalone is built in this CMake instance, add a dependency on it
@@ -24,6 +23,7 @@ function(catch_add_test target)
 		add_dependencies(${target} catch_ros_standalone)
 	endif()
 
+	target_compile_features(${target} PUBLIC cxx_std_11)
 	target_link_libraries(${target}
 		@(DEVELSPACE ? CATKIN_DEVEL_PREFIX : CMAKE_INSTALL_PREFIX)/lib/libcatch_ros_standalone.so
 	)
@@ -55,9 +55,11 @@ endfunction()
 # :type source_files: list of strings
 #
 function(catch_add_rostest_node target)
+	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${target}_meta_info.cpp"
+	"extern \"C\" { const char* catch_ros_local_package_name = \"${PROJECT_NAME}\"; }")
 	add_executable(${target}
 		${ARGN}
-		@(DEVELSPACE ? (PROJECT_SOURCE_DIR + "/src") : (CMAKE_INSTALL_PREFIX + "/" + CATKIN_PACKAGE_SHARE_DESTINATION))/meta_info.cpp
+		"${CMAKE_CURRENT_BINARY_DIR}/${target}_meta_info.cpp"
 	)
 
 	# If catch_ros_rostest is built in this CMake instance, add a dependency on it
@@ -70,6 +72,7 @@ function(catch_add_rostest_node target)
 		add_dependencies(tests ${target})
 	endif()
 
+	target_compile_features(${target} PUBLIC cxx_std_11)
 	target_link_libraries(${target}
 		@(DEVELSPACE ? CATKIN_DEVEL_PREFIX : CMAKE_INSTALL_PREFIX)/lib/libcatch_ros_rostest.so
 	)

--- a/src/meta_info.cpp
+++ b/src/meta_info.cpp
@@ -1,7 +1,8 @@
 // Tell catch_ros about the package we are using it in
-// Author: Max Schwarz <max.schwarz@uni-bonn.de>
+// Original Author: Max Schwarz <max.schwarz@uni-bonn.de>
+// Rewritten using dlopen() by Timo Röhling <timo.roehling@fkie.fraunhofer.de>
 
-// This file is compiled in the package using catch_ros!
+#include <dlfcn.h>
 
 namespace catch_ros
 {
@@ -9,7 +10,21 @@ namespace catch_ros
 	{
 		const char* packageName()
 		{
-			return ROS_PACKAGE_NAME;
+			static const char* package_name = nullptr;
+			if (package_name == nullptr)
+			{
+				void* handle = dlopen(nullptr, RTLD_NOW);
+				if (handle)
+				{
+					const char* const* package_name_ptr = reinterpret_cast<const char* const*>(dlsym(handle, "catch_ros_local_package_name"));
+					if (package_name_ptr)
+						package_name = *package_name_ptr;
+					dlclose(handle);
+				}
+				if (package_name == nullptr)
+					package_name = "UNKNOWN";
+			}
+			return package_name;
 		}
 	}
 }


### PR DESCRIPTION
The original implementation deliberately left a dynamic symbol
unresolved, which does not work with -Wl,-z,defs.

The new implementation uses dlopen() to explicitly look for a
symbol with the package name.