### PR TITLE
Use a weak symbol rather than dlopen() for catch_ros::meta::packageName()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@
 cmake_minimum_required(VERSION 3.4)
 project(catch_ros)
 
-find_package(catkin REQUIRED COMPONENTS roscpp)
+find_package(catkin REQUIRED COMPONENTS
+	roscpp
+)
+
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
 catkin_package(
@@ -13,18 +16,23 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 add_library(catch_ros_standalone
-	src/standalone_main.cpp src/meta_info.cpp
+	src/standalone_main.cpp
 )
-target_compile_features(catch_ros_standalone PUBLIC cxx_std_11)
-target_link_libraries(catch_ros_standalone PRIVATE ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(catch_ros_standalone
+	${Boost_LIBRARIES}
+)
 
 add_library(catch_ros_rostest
-	src/rostest_main.cpp src/meta_info.cpp
+	src/rostest_main.cpp
 )
-target_compile_features(catch_ros_rostest PUBLIC cxx_std_11)
-target_link_libraries(catch_ros_rostest PRIVATE ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(catch_ros_rostest
+	${Boost_LIBRARIES}
+)
 
+install(FILES src/meta_info.cpp DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(TARGETS catch_ros_standalone catch_ros_rostest
 	LIBRARY DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
 )
@@ -32,3 +40,4 @@ install(TARGETS catch_ros_standalone catch_ros_rostest
 install(DIRECTORY include/${PROJECT_NAME}/
 	DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.13)
 project(catch_ros)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -20,16 +20,24 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 add_library(catch_ros_standalone
 	src/standalone_main.cpp
+	src/meta_info_unknown.cpp
 )
 target_link_libraries(catch_ros_standalone
 	${Boost_LIBRARIES}
 )
+target_link_options(catch_ros_standalone PRIVATE
+	"-Wl,-z,defs"
+)
 
 add_library(catch_ros_rostest
 	src/rostest_main.cpp
+	src/meta_info_unknown.cpp
 )
 target_link_libraries(catch_ros_rostest
 	${Boost_LIBRARIES}
+)
+target_link_options(catch_ros_standalone PRIVATE
+	"-Wl,-z,defs"
 )
 
 install(FILES src/meta_info.cpp DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/cmake/catch.cmake.em
+++ b/cmake/catch.cmake.em
@@ -1,3 +1,6 @@
+
+add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")
+
 #
 # Add a Catch executable target.
 #
@@ -11,11 +14,9 @@
 # :type source_files: list of strings
 #
 function(catch_add_test target)
-	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${target}_meta_info.cpp"
-	"extern \"C\" { const char* catch_ros_local_package_name = \"${PROJECT_NAME}\"; }")
 	add_executable(${target}
 		${ARGN}
-		"${CMAKE_CURRENT_BINARY_DIR}/${target}_meta_info.cpp"
+		@(DEVELSPACE ? (PROJECT_SOURCE_DIR + "/src") : (CMAKE_INSTALL_PREFIX + "/" + CATKIN_PACKAGE_SHARE_DESTINATION))/meta_info.cpp
 	)
 
 	# If catch_ros_standalone is built in this CMake instance, add a dependency on it
@@ -23,7 +24,6 @@ function(catch_add_test target)
 		add_dependencies(${target} catch_ros_standalone)
 	endif()
 
-	target_compile_features(${target} PUBLIC cxx_std_11)
 	target_link_libraries(${target}
 		@(DEVELSPACE ? CATKIN_DEVEL_PREFIX : CMAKE_INSTALL_PREFIX)/lib/libcatch_ros_standalone.so
 	)
@@ -55,11 +55,9 @@ endfunction()
 # :type source_files: list of strings
 #
 function(catch_add_rostest_node target)
-	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${target}_meta_info.cpp"
-	"extern \"C\" { const char* catch_ros_local_package_name = \"${PROJECT_NAME}\"; }")
 	add_executable(${target}
 		${ARGN}
-		"${CMAKE_CURRENT_BINARY_DIR}/${target}_meta_info.cpp"
+		@(DEVELSPACE ? (PROJECT_SOURCE_DIR + "/src") : (CMAKE_INSTALL_PREFIX + "/" + CATKIN_PACKAGE_SHARE_DESTINATION))/meta_info.cpp
 	)
 
 	# If catch_ros_rostest is built in this CMake instance, add a dependency on it
@@ -72,7 +70,6 @@ function(catch_add_rostest_node target)
 		add_dependencies(tests ${target})
 	endif()
 
-	target_compile_features(${target} PUBLIC cxx_std_11)
 	target_link_libraries(${target}
 		@(DEVELSPACE ? CATKIN_DEVEL_PREFIX : CMAKE_INSTALL_PREFIX)/lib/libcatch_ros_rostest.so
 	)

--- a/src/meta_info.cpp
+++ b/src/meta_info.cpp
@@ -1,8 +1,7 @@
 // Tell catch_ros about the package we are using it in
-// Original Author: Max Schwarz <max.schwarz@uni-bonn.de>
-// Rewritten using dlopen() by Timo Röhling <timo.roehling@fkie.fraunhofer.de>
+// Author: Max Schwarz <max.schwarz@uni-bonn.de>
 
-#include <dlfcn.h>
+// This file is compiled in the package using catch_ros!
 
 namespace catch_ros
 {
@@ -10,21 +9,7 @@ namespace catch_ros
 	{
 		const char* packageName()
 		{
-			static const char* package_name = nullptr;
-			if (package_name == nullptr)
-			{
-				void* handle = dlopen(nullptr, RTLD_NOW);
-				if (handle)
-				{
-					const char* const* package_name_ptr = reinterpret_cast<const char* const*>(dlsym(handle, "catch_ros_local_package_name"));
-					if (package_name_ptr)
-						package_name = *package_name_ptr;
-					dlclose(handle);
-				}
-				if (package_name == nullptr)
-					package_name = "UNKNOWN";
-			}
-			return package_name;
+			return ROS_PACKAGE_NAME;
 		}
 	}
 }

--- a/src/meta_info_unknown.cpp
+++ b/src/meta_info_unknown.cpp
@@ -1,0 +1,15 @@
+// Tell catch_ros about the package we are using it in
+// Author: Max Schwarz <max.schwarz@uni-bonn.de>
+
+// This file is compiled in the package using catch_ros!
+
+namespace catch_ros
+{
+	namespace meta
+	{
+		const char* __attribute__((weak)) packageName()
+		{
+			return "UNKNOWN";
+		}
+	}
+}


### PR DESCRIPTION
I reproduced problems reported by @knorth55 in #16 - the package name shows up as `UNKNOWN` in the resulting xml files.

It seems that `dlsym()` does not reliably find symbols defined in the main executable - unless `-rdynamic` is used to link the executable (see https://stackoverflow.com/questions/37104928/dlsym-returns-null-even-though-the-symbol-exists).

Thinking about the problem I found another solution: We can define a weak version of `catch_ros::meta::packageName()` in `catch_ros`, which is then overridden by the main executable.

We also add `-Wl,-z,defs` to our link options to test that. @roehling that should cover your use case as well, right?

@knorth55 Could you test if this fixes your issue?