### PR TITLE
Drop -std=c++11 again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
 add_library(catch_ros_standalone
 	src/standalone_main.cpp
 	src/meta_info_unknown.cpp


### PR DESCRIPTION
Was accidentally reintroduced in fcfc75ce24ad8aa70649365b79b268dfa782706e.

Fixes #20.